### PR TITLE
Faster IP Tree

### DIFF
--- a/src/fast_ip.rs
+++ b/src/fast_ip.rs
@@ -1,0 +1,270 @@
+// Fast IP radix tree using tree-bitmap algorithm
+use crate::treebitmap::FastTreeBitmap;
+use crate::utils::canonicalize_ipnet;
+use ipnet::IpNet;
+use std::collections::HashSet;
+
+#[derive(Debug)]
+pub struct FastIpRadixTree {
+    tree: FastTreeBitmap,
+    acl_mode: bool,
+}
+
+impl FastIpRadixTree {
+    pub fn new(acl_mode: bool) -> Self {
+        Self {
+            tree: FastTreeBitmap::new(),
+            acl_mode,
+        }
+    }
+
+    pub fn with_capacity(capacity: usize, acl_mode: bool) -> Self {
+        Self {
+            tree: FastTreeBitmap::with_capacity(capacity),
+            acl_mode,
+        }
+    }
+
+    pub fn insert(&mut self, network: IpNet) -> Option<String> {
+        let canonical = canonicalize_ipnet(&network);
+
+        // If ACL mode is enabled, check if the network is already covered by the tree
+        if self.acl_mode && self.get(&canonical).is_some() {
+            return None; // Skip insertion if already covered
+        }
+
+        self.tree.insert(canonical);
+        Some(canonical.to_string())
+    }
+
+    pub fn get(&self, net: &IpNet) -> Option<String> {
+        let canonical = canonicalize_ipnet(net);
+
+        // For longest prefix matching, we need to find the most specific network
+        // that contains the given network's base address
+        self.tree.longest_match(&canonical).map(|n| n.to_string())
+    }
+
+    pub fn delete(&mut self, network: IpNet) -> bool {
+        let canonical = canonicalize_ipnet(&network);
+        self.tree.remove(&canonical).is_some()
+    }
+
+    pub fn len(&self) -> usize {
+        self.tree.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tree.is_empty()
+    }
+
+    pub fn prune(&mut self) -> usize {
+        // Tree-bitmap doesn't need pruning like the old HashMap-based implementation
+        0
+    }
+
+    pub fn hosts(&self) -> HashSet<String> {
+        let mut hosts = HashSet::new();
+        // Iterate through all stored networks in the tree
+        for network in self.tree.all_networks() {
+            hosts.insert(network.to_string());
+        }
+        hosts
+    }
+
+    pub fn defrag(&mut self) -> (HashSet<String>, HashSet<String>) {
+        // Implement defragmentation by finding mergeable network pairs
+        let mut cleaned = HashSet::new();
+        let mut new = HashSet::new();
+
+        loop {
+            let pairs = self.find_mergeable_pairs();
+            if pairs.is_empty() {
+                break;
+            }
+
+            for (left_net, right_net, supernet) in pairs {
+                cleaned.insert(left_net.to_string());
+                cleaned.insert(right_net.to_string());
+                new.insert(supernet.to_string());
+
+                self.delete(left_net);
+                self.delete(right_net);
+                self.insert(supernet);
+            }
+        }
+
+        // Remove any overlap between cleaned and new
+        let overlap: HashSet<_> = cleaned.intersection(&new).cloned().collect();
+        for k in &overlap {
+            cleaned.remove(k);
+            new.remove(k);
+        }
+
+        (cleaned, new)
+    }
+
+    fn find_mergeable_pairs(&self) -> Vec<(IpNet, IpNet, IpNet)> {
+        use ipnet::{Ipv4Net, Ipv6Net};
+        use std::collections::HashMap;
+
+        let mut pairs = Vec::new();
+        let mut networks_by_prefix: HashMap<u8, Vec<IpNet>> = HashMap::new();
+
+        // Group networks by prefix length
+        for network in self.tree.all_networks() {
+            networks_by_prefix
+                .entry(network.prefix_len())
+                .or_default()
+                .push(network);
+        }
+
+        // Check each prefix length for mergeable pairs
+        for (prefix_len, networks) in networks_by_prefix {
+            if prefix_len == 0 {
+                continue; // Can't merge default routes
+            }
+
+            for i in 0..networks.len() {
+                for j in i + 1..networks.len() {
+                    let left = &networks[i];
+                    let right = &networks[j];
+
+                    // Check if they can be merged
+                    let supernet = match (left, right) {
+                        (IpNet::V4(l), IpNet::V4(r)) => {
+                            if prefix_len > 0 && prefix_len <= 32 {
+                                let mask = if prefix_len == 32 {
+                                    0xffffffffu32
+                                } else {
+                                    !(0xffffffffu32 >> prefix_len)
+                                };
+                                let l_addr = u32::from(l.network());
+                                let r_addr = u32::from(r.network());
+                                if (l_addr ^ r_addr) == (1 << (32 - prefix_len)) {
+                                    let min_addr = l_addr.min(r_addr) & mask;
+                                    Some(IpNet::V4(
+                                        Ipv4Net::new(min_addr.into(), prefix_len - 1).unwrap(),
+                                    ))
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            }
+                        }
+                        (IpNet::V6(l), IpNet::V6(r)) => {
+                            if prefix_len > 0 && prefix_len <= 128 {
+                                let mask = if prefix_len == 128 {
+                                    0xffffffffffffffffffffffffffffffffu128
+                                } else {
+                                    !(0xffffffffffffffffffffffffffffffffu128 >> prefix_len)
+                                };
+                                let l_addr = u128::from(l.network());
+                                let r_addr = u128::from(r.network());
+                                if (l_addr ^ r_addr) == (1 << (128 - prefix_len)) {
+                                    let min_addr = l_addr.min(r_addr) & mask;
+                                    Some(IpNet::V6(
+                                        Ipv6Net::new(min_addr.into(), prefix_len - 1).unwrap(),
+                                    ))
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            }
+                        }
+                        _ => None, // Can't merge IPv4 and IPv6
+                    };
+
+                    if let Some(supernet) = supernet {
+                        pairs.push((*left, *right, supernet));
+                    }
+                }
+            }
+        }
+
+        pairs
+    }
+}
+
+impl Clone for FastIpRadixTree {
+    fn clone(&self) -> Self {
+        let mut new_tree = FastIpRadixTree::new(self.acl_mode);
+        // Copy all networks from the original tree
+        for network in self.tree.all_networks() {
+            new_tree.insert(network);
+        }
+        new_tree
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_insert_and_get_ipv4() {
+        let mut tree = FastIpRadixTree::new(false);
+        let net = IpNet::from_str("192.168.1.0/24").unwrap();
+
+        assert_eq!(tree.insert(net), Some(net.to_string()));
+        assert_eq!(tree.len(), 1);
+
+        // Test lookup with host IP
+        let host = IpNet::from_str("192.168.1.100/32").unwrap();
+        assert_eq!(tree.get(&host), Some(net.to_string()));
+
+        // Test no match
+        let no_match = IpNet::from_str("10.0.0.1/32").unwrap();
+        assert_eq!(tree.get(&no_match), None);
+    }
+
+    #[test]
+    fn test_insert_and_get_ipv6() {
+        let mut tree = FastIpRadixTree::new(false);
+        let net = IpNet::from_str("2001:db8::/64").unwrap();
+
+        assert_eq!(tree.insert(net), Some(net.to_string()));
+
+        let host = IpNet::from_str("2001:db8::1/128").unwrap();
+        assert_eq!(tree.get(&host), Some(net.to_string()));
+    }
+
+    #[test]
+    fn test_overlapping_networks() {
+        let mut tree = FastIpRadixTree::new(false);
+        let broad = IpNet::from_str("10.0.0.0/8").unwrap();
+        let specific = IpNet::from_str("10.1.0.0/16").unwrap();
+        let most_specific = IpNet::from_str("10.1.1.0/24").unwrap();
+
+        tree.insert(broad);
+        tree.insert(specific);
+        tree.insert(most_specific);
+
+        // Should match most specific
+        let host1 = IpNet::from_str("10.1.1.100/32").unwrap();
+        assert_eq!(tree.get(&host1), Some(most_specific.to_string()));
+
+        // Should match intermediate
+        let host2 = IpNet::from_str("10.1.2.100/32").unwrap();
+        assert_eq!(tree.get(&host2), Some(specific.to_string()));
+
+        // Should match broad
+        let host3 = IpNet::from_str("10.2.0.1/32").unwrap();
+        assert_eq!(tree.get(&host3), Some(broad.to_string()));
+    }
+
+    #[test]
+    fn test_acl_mode() {
+        let mut tree = FastIpRadixTree::new(true);
+        let broad = IpNet::from_str("10.0.0.0/8").unwrap();
+        let specific = IpNet::from_str("10.1.0.0/16").unwrap();
+
+        tree.insert(broad);
+        // In ACL mode, more specific networks should be skipped if already covered
+        assert_eq!(tree.insert(specific), None);
+        assert_eq!(tree.len(), 1);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,11 @@ use pyo3::prelude::*;
 use pyo3::types::PyList;
 
 pub mod dns;
+pub mod fast_ip;
 pub mod ip;
 pub mod node;
 pub mod target;
+pub mod treebitmap;
 pub mod utils;
 
 pub use dns::ScopeMode;

--- a/src/treebitmap.rs
+++ b/src/treebitmap.rs
@@ -1,0 +1,524 @@
+// Fast tree-bitmap implementation for IP prefix lookups
+// Based on the Tree-bitmap algorithm by W. Eatherton, Z. Dittia, G. Varghes
+// Provides O(log n) operations with efficient memory usage
+
+use ipnet::IpNet;
+use std::cmp;
+
+// Tree-bitmap core modules
+mod allocator;
+mod node;
+
+use allocator::{Allocator, AllocatorHandle};
+use node::{MatchResult, Node};
+
+/// Convert IpNet to nibbles (4-bit chunks) for tree-bitmap traversal
+fn ipnet_to_nibbles(network: &IpNet) -> (Vec<u8>, u32) {
+    match network {
+        IpNet::V4(net) => {
+            let addr = net.addr();
+            let octets = addr.octets();
+            let mut nibbles = Vec::with_capacity(8);
+            for byte in octets {
+                nibbles.push(byte >> 4);
+                nibbles.push(byte & 0xf);
+            }
+            (nibbles, net.prefix_len().into())
+        }
+        IpNet::V6(net) => {
+            let addr = net.addr();
+            let octets = addr.octets();
+            let mut nibbles = Vec::with_capacity(32);
+            for byte in octets {
+                nibbles.push(byte >> 4);
+                nibbles.push(byte & 0xf);
+            }
+            (nibbles, net.prefix_len().into())
+        }
+    }
+}
+
+
+/// Fast tree-bitmap implementation for IP prefix lookups
+#[derive(Debug)]
+pub struct FastTreeBitmap {
+    tree: TreeBitmap<IpNet>,
+}
+
+/// Core TreeBitmap structure - copied from working implementation
+#[derive(Debug)]
+struct TreeBitmap<T: Sized> {
+    trienodes: Allocator<Node>,
+    results: Allocator<T>,
+    len: usize,
+    should_drop: bool,
+}
+
+impl<T: Sized> TreeBitmap<T> {
+    /// Returns TreeBitmap with 0 start capacity.
+    pub fn new() -> Self {
+        Self::with_capacity(0)
+    }
+
+    /// Returns TreeBitmap with pre-allocated buffers of size n.
+    pub fn with_capacity(n: usize) -> Self {
+        let mut trieallocator: Allocator<Node> = Allocator::with_capacity(n);
+        let mut root_hdl = trieallocator.alloc(0);
+        trieallocator.insert(&mut root_hdl, 0, Node::new());
+
+        TreeBitmap {
+            trienodes: trieallocator,
+            results: Allocator::with_capacity(n),
+            len: 0,
+            should_drop: true,
+        }
+    }
+
+    /// Returns handle to root node.
+    fn root_handle(&self) -> AllocatorHandle {
+        AllocatorHandle::generate(1, 0)
+    }
+
+    /// Push down results encoded in the last 16 bits into child trie nodes.
+    /// Makes ```node``` into a normal node.
+    fn push_down(&mut self, node: &mut Node) {
+        debug_assert!(node.is_endnode(), "push_down: not an endnode");
+        debug_assert!(node.child_ptr == 0);
+        // count number of internal nodes in the first 15 bits (those that will
+        // remain in place).
+        let internal_node_count = (node.internal() & 0xffff_0000).count_ones();
+        let remove_at = internal_node_count;
+        // count how many nodes to push down
+        let nodes_to_pushdown = (node.internal() & 0x0000_ffff).count_ones();
+        if nodes_to_pushdown > 0 {
+            let mut result_hdl = node.result_handle();
+            let mut child_node_hdl = self.trienodes.alloc(0);
+
+            for _ in 0..nodes_to_pushdown {
+                // allocate space for child result value
+                let mut child_result_hdl = self.results.alloc(0);
+                // put result value in freshly allocated bucket
+                let result_value = self.results.remove(&mut result_hdl, remove_at);
+                self.results.insert(&mut child_result_hdl, 0, result_value);
+                // create and save child node
+                let mut child_node = Node::new();
+                child_node.set_internal(1 << 31);
+                child_node.result_ptr = child_result_hdl.offset;
+                // append trienode to collection
+                let insert_node_at = child_node_hdl.len;
+                self.trienodes
+                    .insert(&mut child_node_hdl, insert_node_at, child_node);
+            }
+            // the result data may have moved to a smaller bucket, update the
+            // result pointer
+            node.result_ptr = result_hdl.offset;
+            node.child_ptr = child_node_hdl.offset;
+            // no results from this node remain, free the result slot
+            if internal_node_count == 0 && nodes_to_pushdown > 0 {
+                self.results.free(&mut result_hdl);
+                node.result_ptr = 0;
+            }
+        }
+        node.make_normalnode();
+        // note: we do not need to touch the external bits
+    }
+
+    /// longest match lookup of ```nibbles```. Returns bits matched as u32, and reference to T.
+    pub fn longest_match(&self, nibbles: &[u8]) -> Option<(u32, &T)> {
+        let mut cur_hdl = self.root_handle();
+        let mut cur_index = 0;
+        let mut bits_matched = 0;
+        let mut bits_searched = 0;
+        let mut best_match: Option<(AllocatorHandle, u32)> = None; // result handle + index
+
+        for nibble in nibbles {
+            let cur_node = *self.trienodes.get(&cur_hdl, cur_index);
+            let match_mask = node::MATCH_MASKS[*nibble as usize];
+
+            if let MatchResult::Match(result_hdl, result_index, matching_bit_index) =
+                cur_node.match_internal(match_mask)
+            {
+                bits_matched = bits_searched;
+                bits_matched += node::BIT_MATCH[matching_bit_index as usize];
+                best_match = Some((result_hdl, result_index));
+            }
+
+            if cur_node.is_endnode() {
+                break;
+            }
+            match cur_node.match_external(match_mask) {
+                MatchResult::Chase(child_hdl, child_index) => {
+                    bits_searched += 4;
+                    cur_hdl = child_hdl;
+                    cur_index = child_index;
+                    continue;
+                }
+                MatchResult::None => {
+                    break;
+                }
+                _ => unreachable!(),
+            }
+        }
+
+        match best_match {
+            Some((result_hdl, result_index)) => {
+                Some((bits_matched, self.results.get(&result_hdl, result_index)))
+            }
+            None => None,
+        }
+    }
+
+    pub fn insert(&mut self, nibbles: &[u8], masklen: u32, value: T) -> Option<T> {
+        let mut cur_hdl = self.root_handle();
+        let mut cur_index = 0;
+        let mut bits_left = masklen;
+        let mut ret = None;
+
+        let mut loop_count = 0;
+        loop {
+            let nibble = if loop_count < nibbles.len() {
+                nibbles[loop_count]
+            } else {
+                0
+            };
+            loop_count += 1;
+
+            let mut cur_node = *self.trienodes.get(&cur_hdl, cur_index);
+            let match_result = cur_node.match_segment(nibble);
+
+            if let MatchResult::Chase(child_hdl, index) = match_result
+                && bits_left >= 4 {
+                    // follow existing branch
+                    bits_left -= 4;
+                    cur_hdl = child_hdl;
+                    cur_index = index;
+                    continue;
+                }
+
+            let bitmap = node::gen_bitmap(nibble, cmp::min(4, bits_left));
+
+            if (cur_node.is_endnode() && bits_left <= 4) || bits_left <= 3 {
+                // final node reached, insert results
+                let mut result_hdl = match cur_node.result_count() {
+                    0 => self.results.alloc(0),
+                    _ => cur_node.result_handle(),
+                };
+                let result_index = (cur_node.internal()
+                    >> (bitmap & node::END_BIT_MASK).trailing_zeros())
+                .count_ones();
+
+                if cur_node.internal() & (bitmap & node::END_BIT_MASK) > 0 {
+                    // key already exists!
+                    ret = Some(self.results.replace(&result_hdl, result_index - 1, value));
+                } else {
+                    cur_node.set_internal(bitmap & node::END_BIT_MASK);
+                    self.results.insert(&mut result_hdl, result_index, value); // add result
+                    self.len += 1;
+                }
+                cur_node.result_ptr = result_hdl.offset;
+                self.trienodes.set(&cur_hdl, cur_index, cur_node); // save trie node
+                return ret;
+            }
+            // add a branch
+
+            if cur_node.is_endnode() {
+                // move any result pointers out of the way, so we can add branch
+                self.push_down(&mut cur_node);
+            }
+            let mut child_hdl = match cur_node.child_count() {
+                0 => self.trienodes.alloc(0),
+                _ => cur_node.child_handle(),
+            };
+
+            let child_index = (cur_node.external() >> bitmap.trailing_zeros()).count_ones();
+
+            if cur_node.external() & (bitmap & node::END_BIT_MASK) == 0 {
+                // no existing branch; create it
+                cur_node.set_external(bitmap & node::END_BIT_MASK);
+            } else {
+                // follow existing branch
+                if let MatchResult::Chase(child_hdl, index) = cur_node.match_segment(nibble) {
+                    self.trienodes.set(&cur_hdl, cur_index, cur_node); // save trie node
+                    bits_left -= 4;
+                    cur_hdl = child_hdl;
+                    cur_index = index;
+                    continue;
+                }
+                unreachable!()
+            }
+
+            // prepare a child node
+            let mut child_node = Node::new();
+            child_node.make_endnode();
+            self.trienodes
+                .insert(&mut child_hdl, child_index, child_node); // save child
+            cur_node.child_ptr = child_hdl.offset;
+            self.trienodes.set(&cur_hdl, cur_index, cur_node); // save trie node
+
+            bits_left -= 4;
+            cur_hdl = child_hdl;
+            cur_index = child_index;
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn exact_match(&self, nibbles: &[u8], masklen: u32) -> Option<&T> {
+        let mut cur_hdl = self.root_handle();
+        let mut cur_index = 0;
+        let mut bits_left = masklen;
+
+        for nibble in nibbles {
+            let cur_node = self.trienodes.get(&cur_hdl, cur_index);
+            let bitmap = node::gen_bitmap(*nibble, cmp::min(bits_left, 4)) & node::END_BIT_MASK;
+            let reached_final_node = bits_left < 4 || (cur_node.is_endnode() && bits_left == 4);
+
+            if reached_final_node {
+                match cur_node.match_internal(bitmap) {
+                    MatchResult::Match(result_hdl, result_index, _) => {
+                        return Some(self.results.get(&result_hdl, result_index));
+                    }
+                    _ => return None,
+                }
+            }
+
+            match cur_node.match_external(bitmap) {
+                MatchResult::Chase(child_hdl, child_index) => {
+                    cur_hdl = child_hdl;
+                    cur_index = child_index;
+                    bits_left -= 4;
+                }
+                _ => return None,
+            }
+        }
+        None
+    }
+
+    /// Remove prefix. Returns existing value if the prefix previously existed.
+    pub fn remove(&mut self, nibbles: &[u8], masklen: u32) -> Option<T> {
+        debug_assert!(nibbles.len() >= (masklen / 4) as usize);
+        let root_hdl = self.root_handle();
+        let mut root_node = *self.trienodes.get(&root_hdl, 0);
+        let ret = self.remove_child(&mut root_node, nibbles, masklen);
+        self.trienodes.set(&root_hdl, 0, root_node);
+        ret
+    }
+
+    // remove child and result from node
+    fn remove_child(&mut self, node: &mut Node, nibbles: &[u8], masklen: u32) -> Option<T> {
+        let nibble = nibbles[0];
+        let bitmap = node::gen_bitmap(nibble, cmp::min(masklen, 4)) & node::END_BIT_MASK;
+        let reached_final_node = masklen < 4 || (node.is_endnode() && masklen == 4);
+
+        if reached_final_node {
+            match node.match_internal(bitmap) {
+                MatchResult::Match(mut result_hdl, result_index, _) => {
+                    node.unset_internal(bitmap);
+                    let ret = self.results.remove(&mut result_hdl, result_index);
+                    if node.result_count() == 0 {
+                        self.results.free(&mut result_hdl);
+                    }
+                    node.result_ptr = result_hdl.offset;
+                    self.len -= 1;
+                    return Some(ret);
+                }
+                _ => return None,
+            }
+        }
+
+        if let MatchResult::Chase(mut child_node_hdl, index) = node.match_external(bitmap) {
+            let mut child_node = *self.trienodes.get(&child_node_hdl, index);
+            let ret = self.remove_child(&mut child_node, &nibbles[1..], masklen - 4);
+
+            if child_node.child_count() == 0 && !child_node.is_endnode() {
+                child_node.make_endnode();
+            }
+            if child_node.is_empty() {
+                self.trienodes.remove(&mut child_node_hdl, index);
+                node.unset_external(bitmap);
+                if child_node_hdl.len == 0 {
+                    // no child nodes
+                    self.trienodes.free(&mut child_node_hdl);
+                }
+                node.child_ptr = child_node_hdl.offset;
+            } else {
+                node.child_ptr = child_node_hdl.offset;
+                self.trienodes.set(&child_node_hdl, index, child_node);
+            }
+            ret
+        } else {
+            None
+        }
+    }
+
+    pub fn iter(&self) -> TreeBitmapIter<'_, T> {
+        let root_hdl = self.root_handle();
+        let root_node = *self.trienodes.get(&root_hdl, 0);
+        TreeBitmapIter {
+            inner: self,
+            path: vec![PathElem {
+                node: root_node,
+                pos: 0,
+            }],
+            nibbles: vec![0],
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PathElem {
+    node: Node,
+    pos: usize,
+}
+
+pub struct TreeBitmapIter<'a, T: 'a> {
+    inner: &'a TreeBitmap<T>,
+    path: Vec<PathElem>,
+    nibbles: Vec<u8>,
+}
+
+#[rustfmt::skip]
+static PREFIX_OF_BIT: [u8; 32] = [// 0       1       2      3        4       5       6       7
+                                  0b0000, 0b0000, 0b1000, 0b0000, 0b0100, 0b1000, 0b1100, 0b0000,
+                                  // 8       9      10      11      12      13      14      15
+                                  0b0010, 0b0100, 0b0110, 0b1000, 0b1010, 0b1100, 0b1110,      0,
+                                  // 16      17      18      19      20      21      22      23
+                                  0b0000, 0b0001, 0b0010, 0b0011, 0b0100, 0b0101, 0b0110, 0b0111,
+                                  // 24      25      26      27      28      29      30      31
+                                  0b1000, 0b1001, 0b1010, 0b1011, 0b1100, 0b1101, 0b1110, 0b1111];
+
+fn tree_next<T: Sized>(
+    trie: &TreeBitmap<T>,
+    path: &mut Vec<PathElem>,
+    nibbles: &mut Vec<u8>,
+) -> Option<(Vec<u8>, u32, AllocatorHandle, u32)> {
+    loop {
+        let mut path_elem = path.pop()?;
+        let cur_node = path_elem.node;
+        let mut cur_pos = path_elem.pos;
+        nibbles.pop();
+        // optim:
+        if cur_pos == 0 && cur_node.result_count() == 0 {
+            path_elem.pos = 16;
+            cur_pos = 16;
+        }
+        if path_elem.pos == 32 {
+            continue;
+        }
+        let nibble = PREFIX_OF_BIT[path_elem.pos];
+        let bitmap = 1 << (31 - path_elem.pos);
+
+        path_elem.pos += 1;
+        nibbles.push(nibble);
+        path.push(path_elem);
+        // match internal
+        if cur_pos < 16 || cur_node.is_endnode() {
+            let match_result = cur_node.match_internal(bitmap);
+            if let MatchResult::Match(result_hdl, result_index, matching_bit) = match_result {
+                let bits_matched =
+                    ((path.len() as u32) - 1) * 4 + node::BIT_MATCH[matching_bit as usize];
+                return Some((nibbles.clone(), bits_matched, result_hdl, result_index));
+            }
+        } else if let MatchResult::Chase(child_hdl, child_index) = cur_node.match_external(bitmap) {
+            let child_node = trie.trienodes.get(&child_hdl, child_index);
+            nibbles.push(0);
+            path.push(PathElem {
+                node: *child_node,
+                pos: 0,
+            });
+        }
+    }
+}
+
+impl<'a, T: 'a> Iterator for TreeBitmapIter<'a, T> {
+    type Item = (Vec<u8>, u32, &'a T); //(nibbles, masklen, &T)
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match tree_next(self.inner, &mut self.path, &mut self.nibbles) {
+            Some((path, bits_matched, hdl, index)) => {
+                let value = self.inner.results.get(&hdl, index);
+                Some((path, bits_matched, value))
+            }
+            None => None,
+        }
+    }
+}
+
+impl<T> Drop for TreeBitmap<T> {
+    fn drop(&mut self) {
+        if self.should_drop {
+            for (_, _, item) in self.iter() {
+                unsafe {
+                    std::ptr::read(item);
+                }
+            }
+        }
+    }
+}
+
+impl FastTreeBitmap {
+    pub fn new() -> Self {
+        Self {
+            tree: TreeBitmap::new(),
+        }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            tree: TreeBitmap::with_capacity(capacity),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.tree.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.tree.len() == 0
+    }
+
+    /// Get all stored networks
+    pub fn all_networks(&self) -> Vec<IpNet> {
+        let mut networks = Vec::new();
+        for (_nibbles, _masklen, network) in self.tree.iter() {
+            networks.push(*network);
+        }
+        networks
+    }
+
+    pub fn insert(&mut self, network: IpNet) -> Option<IpNet> {
+        let canonical = crate::utils::canonicalize_ipnet(&network);
+        let (nibbles, masklen) = ipnet_to_nibbles(&canonical);
+        self.tree.insert(&nibbles, masklen, canonical)
+    }
+
+    pub fn longest_match(&self, network: &IpNet) -> Option<&IpNet> {
+        let canonical = crate::utils::canonicalize_ipnet(network);
+        let (nibbles, _) = ipnet_to_nibbles(&canonical);
+
+        match self.tree.longest_match(&nibbles) {
+            Some((_, result)) => Some(result),
+            None => None,
+        }
+    }
+
+    pub fn exact_match(&self, network: &IpNet) -> Option<&IpNet> {
+        let canonical = crate::utils::canonicalize_ipnet(network);
+        let (nibbles, masklen) = ipnet_to_nibbles(&canonical);
+        self.tree.exact_match(&nibbles, masklen)
+    }
+
+    pub fn remove(&mut self, network: &IpNet) -> Option<IpNet> {
+        let canonical = crate::utils::canonicalize_ipnet(network);
+        let (nibbles, masklen) = ipnet_to_nibbles(&canonical);
+        self.tree.remove(&nibbles, masklen)
+    }
+}
+
+impl Default for FastTreeBitmap {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/treebitmap/allocator.rs
+++ b/src/treebitmap/allocator.rs
@@ -1,0 +1,368 @@
+// Copyright 2016 Hroi Sigurdsson
+//
+// Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.
+// This file may not be copied, modified, or distributed except according to those terms.
+
+use std::cmp;
+use std::fmt;
+use std::mem;
+use std::ptr;
+
+struct RawVec<T> {
+    mem: *mut T,
+    cap: usize,
+}
+
+impl<T> RawVec<T> {
+    pub fn with_capacity(cap: usize) -> RawVec<T> {
+        let mut vec = Vec::<T>::with_capacity(cap);
+        let ptr = vec.as_mut_ptr();
+        mem::forget(vec);
+        RawVec { mem: ptr, cap }
+    }
+
+    pub fn cap(&self) -> usize {
+        self.cap
+    }
+
+    pub fn ptr(&self) -> *mut T {
+        self.mem
+    }
+
+    pub fn reserve(&mut self, used_cap: usize, extra_cap: usize) {
+        let mut vec = unsafe { Vec::<T>::from_raw_parts(self.mem, used_cap, self.cap) };
+        vec.reserve(extra_cap);
+        self.cap = vec.capacity();
+        self.mem = vec.as_mut_ptr();
+        mem::forget(vec);
+    }
+}
+
+impl<T> Drop for RawVec<T> {
+    fn drop(&mut self) {
+        unsafe {
+            Vec::from_raw_parts(self.mem, 0, self.cap);
+        }
+    }
+}
+
+unsafe impl<T> Sync for RawVec<T> where T: Sync {}
+
+unsafe impl<T> Send for RawVec<T> where T: Send {}
+
+/// A vector that contains `len / spacing` buckets and each bucket contains `spacing` elements.
+/// Buckets are store contiguously in the vector.
+/// So slots are multiples of `spacing`.
+pub struct BucketVec<T> {
+    buf: RawVec<T>,
+    freelist: Vec<u32>,
+    len: u32,
+    spacing: u32,
+}
+
+impl<T: fmt::Debug> fmt::Debug for BucketVec<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BucketVec")
+            .field("spacing", &self.spacing)
+            .field("freelist", &self.freelist)
+            .field("len", &self.len)
+            .field("cap", &self.buf.cap())
+            .field("buf", &format!("RawVec<T> len={}", self.len))
+            .finish()
+    }
+}
+
+impl<T: Sized> BucketVec<T> {
+    pub fn with_capacity(spacing: u32, capacity: usize) -> BucketVec<T> {
+        BucketVec {
+            buf: RawVec::with_capacity(capacity),
+            freelist: Vec::with_capacity(32),
+            len: 0,
+            spacing,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn new(spacing: u32) -> BucketVec<T> {
+        Self::with_capacity(spacing, 0)
+    }
+
+    /// Allocate a bucket slot.
+    pub fn alloc_slot(&mut self) -> u32 {
+        match self.freelist.pop() {
+            Some(n) => n,
+            None => {
+                self.buf.reserve(self.len as usize, self.spacing as usize);
+                if cfg!(debug_assertions) {
+                    unsafe {
+                        ptr::write_bytes(
+                            self.buf.ptr().offset(self.len as isize),
+                            0,
+                            self.spacing as usize,
+                        );
+                    }
+                }
+                let slot = self.len;
+                self.len += self.spacing;
+                slot
+            }
+        }
+    }
+
+    /// Free a bucket slot.
+    pub fn free_slot(&mut self, slot: u32) {
+        self.freelist.push(slot)
+    }
+
+    #[inline]
+    pub fn get_slot_entry(&self, slot: u32, index: u32) -> &T {
+        debug_assert!(slot.is_multiple_of(self.spacing));
+        let offset = slot + index;
+        unsafe {
+            let src_ptr = self.buf.ptr().offset(offset as isize);
+            &*src_ptr
+        }
+    }
+
+
+    pub fn set_slot_entry(&mut self, slot: u32, index: u32, value: T) {
+        debug_assert!(slot.is_multiple_of(self.spacing));
+        debug_assert!(index < self.spacing);
+        let offset = slot + index;
+        unsafe {
+            let dst_ptr = self.buf.ptr().offset(offset as isize);
+            ptr::write(dst_ptr, value);
+        }
+    }
+
+    pub fn replace_slot_entry(&mut self, slot: u32, index: u32, value: T) -> T {
+        debug_assert!(slot.is_multiple_of(self.spacing));
+        debug_assert!(index < self.spacing);
+        let offset = slot + index;
+        unsafe {
+            let dst_ptr = self.buf.ptr().offset(offset as isize);
+            ptr::replace(dst_ptr, value)
+        }
+    }
+
+    /// Insert ```value``` into ```slot``` at ```index```. Values to the right
+    /// of ```index``` will be moved.
+    /// If all values have been set the last value will be lost.
+    pub fn insert_slot_entry(&mut self, slot: u32, index: u32, value: T) {
+        debug_assert!(slot.is_multiple_of(self.spacing));
+        let offset = slot + index;
+        unsafe {
+            let dst_ptr = self.buf.ptr().offset(offset as isize);
+            ptr::copy(
+                dst_ptr,
+                dst_ptr.offset(1),
+                (self.spacing - index - 1) as usize,
+            );
+            ptr::write(dst_ptr, value);
+        }
+    }
+
+    pub fn remove_slot_entry(&mut self, slot: u32, index: u32) -> T {
+        debug_assert!(slot.is_multiple_of(self.spacing));
+        debug_assert!(index < self.spacing);
+        let offset = slot + index;
+        let ret: T;
+        unsafe {
+            ret = ptr::read(self.buf.ptr().offset(offset as isize));
+            let dst_ptr = self.buf.ptr().offset(offset as isize);
+            ptr::copy(
+                dst_ptr.offset(1),
+                dst_ptr,
+                (self.spacing - index - 1) as usize,
+            );
+            if cfg!(debug_assertions) {
+                ptr::write(
+                    dst_ptr.offset((self.spacing - index - 1) as isize),
+                    mem::zeroed(),
+                );
+            }
+        }
+        ret
+    }
+
+    /// Move contents from one bucket to another.
+    /// Returns the offset of the new location.
+    fn move_slot(&mut self, slot: u32, dst: &mut BucketVec<T>) -> u32 {
+        let nitems = cmp::min(self.spacing, dst.spacing);
+
+        debug_assert!(slot < self.len);
+        debug_assert!(slot.is_multiple_of(self.spacing));
+        debug_assert!(nitems > 0);
+        debug_assert!(nitems <= self.spacing);
+        debug_assert!(nitems <= dst.spacing);
+
+        let dst_slot = dst.alloc_slot();
+
+        unsafe {
+            let src_ptr = self.buf.ptr().offset(slot as isize);
+            let dst_ptr = dst.buf.ptr().offset(dst_slot as isize);
+            ptr::copy_nonoverlapping(src_ptr, dst_ptr, nitems as usize);
+            if cfg!(debug_assertions) {
+                ptr::write_bytes(src_ptr, 0, nitems as usize);
+            }
+        }
+
+        self.free_slot(slot);
+
+        dst_slot
+    }
+
+}
+
+static LEN2BUCKET: [u32; 33] = [
+    0, 0, 1, 2, 2, 3, 3, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8,
+    8,
+];
+
+#[inline]
+pub fn choose_bucket(len: u32) -> u32 {
+    debug_assert!(len < 33);
+    unsafe { *LEN2BUCKET.get_unchecked(len as usize) }
+}
+
+/// ```Allocator``` stores items in exponentially sized buckets (using
+/// ```BucketVec```s for backing).
+///
+/// All interaction is done with an ```AllocatorHandle```used for tracking the
+/// collection size and location.
+/// The location of data is computed based on the collection size and base
+/// pointer (stored in handle).
+/// When a bucket becomes full, the contents are moved to a larger bucket. In
+/// this case the allocator will update the caller's pointer.
+#[derive(Debug)]
+pub struct Allocator<T: Sized> {
+    buckets: [BucketVec<T>; 9],
+}
+
+/// Tracks the size and location of the referenced collection.
+#[derive(Debug)]
+pub struct AllocatorHandle {
+    /// The current length of the collection
+    pub len: u32,
+    /// Basepointer
+    pub offset: u32,
+}
+
+impl AllocatorHandle {
+    #[inline]
+    pub fn generate(len: u32, offset: u32) -> AllocatorHandle {
+        AllocatorHandle { len, offset }
+    }
+}
+
+impl<T: Sized> Allocator<T> {
+    /// Initialize a new allocator with default capacity.
+    #[allow(dead_code)]
+    pub fn new() -> Allocator<T> {
+        Allocator {
+            buckets: [
+                BucketVec::new(1),
+                BucketVec::new(2),
+                BucketVec::new(4),
+                BucketVec::new(6),
+                BucketVec::new(8),
+                BucketVec::new(12),
+                BucketVec::new(16),
+                BucketVec::new(24),
+                BucketVec::new(32),
+            ],
+        }
+    }
+
+    /// Initialize a new ```Allocator``` with specified capacity.
+    pub fn with_capacity(cap: usize) -> Allocator<T> {
+        Allocator {
+            buckets: [
+                BucketVec::with_capacity(1, cap),
+                BucketVec::with_capacity(2, cap),
+                BucketVec::with_capacity(4, cap),
+                BucketVec::with_capacity(6, cap),
+                BucketVec::with_capacity(8, cap),
+                BucketVec::with_capacity(12, cap),
+                BucketVec::with_capacity(16, cap),
+                BucketVec::with_capacity(24, cap),
+                BucketVec::with_capacity(32, cap),
+            ],
+        }
+    }
+
+
+    pub fn alloc(&mut self, count: u32) -> AllocatorHandle {
+        let bucket_index = choose_bucket(count) as usize;
+        let slot = self.buckets[bucket_index].alloc_slot();
+        AllocatorHandle {
+            len: count,
+            offset: slot,
+        }
+    }
+
+    pub fn free(&mut self, hdl: &mut AllocatorHandle) {
+        debug_assert!(hdl.len == 0, "tried to free non-empty collection");
+        let bucket_index = choose_bucket(hdl.len) as usize;
+        self.buckets[bucket_index].free_slot(hdl.offset);
+        hdl.offset = 0;
+    }
+
+    pub fn set(&mut self, hdl: &AllocatorHandle, index: u32, value: T) {
+        let bucket_index = choose_bucket(hdl.len) as usize;
+        self.buckets[bucket_index].set_slot_entry(hdl.offset, index, value)
+    }
+
+    pub fn replace(&mut self, hdl: &AllocatorHandle, index: u32, value: T) -> T {
+        let bucket_index = choose_bucket(hdl.len) as usize;
+        self.buckets[bucket_index].replace_slot_entry(hdl.offset, index, value)
+    }
+
+    #[inline]
+    pub fn get(&self, hdl: &AllocatorHandle, index: u32) -> &T {
+        let bucket_index = choose_bucket(hdl.len) as usize;
+        self.buckets[bucket_index].get_slot_entry(hdl.offset, index)
+    }
+
+
+    pub fn insert(&mut self, hdl: &mut AllocatorHandle, index: u32, value: T) {
+        let mut bucket_index = choose_bucket(hdl.len) as usize;
+        let next_bucket_index = choose_bucket(hdl.len + 1) as usize;
+        let mut slot = hdl.offset;
+
+        debug_assert!(self.buckets[bucket_index].len >= hdl.offset);
+
+        if bucket_index != next_bucket_index {
+            // move to bigger bucket
+            debug_assert!(next_bucket_index > bucket_index);
+            let (left, right) = self.buckets.split_at_mut(bucket_index + 1);
+            slot = left[bucket_index]
+                .move_slot(slot, &mut right[next_bucket_index - bucket_index - 1]);
+            bucket_index = next_bucket_index;
+        }
+
+        hdl.offset = slot;
+        hdl.len += 1;
+
+        self.buckets[bucket_index].insert_slot_entry(slot, index, value)
+    }
+
+    pub fn remove(&mut self, hdl: &mut AllocatorHandle, index: u32) -> T {
+        let bucket_index = choose_bucket(hdl.len) as usize;
+        let next_bucket_index = choose_bucket(hdl.len - 1) as usize;
+        let mut slot = hdl.offset;
+
+        let ret = self.buckets[bucket_index].remove_slot_entry(slot, index);
+
+        if bucket_index != next_bucket_index {
+            // move to smaller bucket
+            debug_assert!(next_bucket_index < bucket_index);
+            let (left, right) = self.buckets.split_at_mut(bucket_index);
+            slot = right[0].move_slot(slot, &mut left[next_bucket_index]);
+        }
+
+        hdl.offset = slot;
+        hdl.len -= 1;
+        ret
+    }
+}

--- a/src/treebitmap/node.rs
+++ b/src/treebitmap/node.rs
@@ -1,0 +1,395 @@
+// Copyright 2016 Hroi Sigurdsson
+//
+// Licensed under the MIT license <LICENSE-MIT or http://opensource.org/licenses/MIT>.
+// This file may not be copied, modified, or distributed except according to those terms.
+
+use super::allocator::AllocatorHandle;
+use std::fmt;
+
+pub const INT_MASK: u32 = 0xffff_0000;
+pub const EXT_MASK: u32 = 0x0000_ffff;
+pub const END_BIT: u32 = 1 << 16;
+pub const END_BIT_MASK: u32 = !END_BIT; // all bits except the end node bit
+
+type Table = [[u32; 16]; 5];
+const IS_END_NODE: u32 = 1 << 16;
+
+#[rustfmt::skip]
+static INTERNAL_LOOKUP_TABLE: Table = [
+    // mask = 00000, 0/0
+    [1<<31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    // mask = 00001, 0-1/1
+    [1<<30, 0, 0, 0, 0, 0, 0, 0, 1<<29, 0, 0, 0, 0, 0, 0, 0],
+    // mask = 00011, 0-3/2
+    [1<<28, 0, 0, 0, 1<<27, 0, 0, 0, 1<<26, 0, 0, 0, 1<<25, 0, 0, 0],
+    // mask = 00111, 0-7/3
+    [1<<24, 0, 1<<23, 0, 1<<22, 0, 1<<21, 0, 1<<20, 0, 1<<19, 0, 1<<18, 0, 1<<17, 0],
+    // endnode indicated in 16 bit, skip
+    // mask = 01111, 0-15/4
+    [IS_END_NODE | 1<<15, IS_END_NODE | 1<<14, IS_END_NODE | 1<<13, IS_END_NODE | 1<<12,
+     IS_END_NODE | 1<<11, IS_END_NODE | 1<<10, IS_END_NODE | 1<< 9, IS_END_NODE | 1<< 8,
+     IS_END_NODE | 1<< 7, IS_END_NODE | 1<< 6, IS_END_NODE | 1<< 5, IS_END_NODE | 1<< 4,
+     IS_END_NODE | 1<< 3, IS_END_NODE | 1<< 2, IS_END_NODE | 1<< 1, IS_END_NODE |     1],
+];
+
+pub const MSB: u32 = 1 << 31;
+
+#[rustfmt::skip]
+pub static MATCH_MASKS: [u32; 16] = [MSB | MSB >> 1 | MSB >> 3 | MSB >>  7 | MSB >> 16, // 0000
+                                     MSB | MSB >> 1 | MSB >> 3 | MSB >>  7 | MSB >> 17, // 0001
+                                     MSB | MSB >> 1 | MSB >> 3 | MSB >>  8 | MSB >> 18, // 0010
+                                     MSB | MSB >> 1 | MSB >> 3 | MSB >>  8 | MSB >> 19, // 0011
+
+                                     MSB | MSB >> 1 | MSB >> 4 | MSB >>  9 | MSB >> 20, // 0100
+                                     MSB | MSB >> 1 | MSB >> 4 | MSB >>  9 | MSB >> 21, // 0101
+                                     MSB | MSB >> 1 | MSB >> 4 | MSB >> 10 | MSB >> 22, // 0110
+                                     MSB | MSB >> 1 | MSB >> 4 | MSB >> 10 | MSB >> 23, // 0111
+
+                                     MSB | MSB >> 2 | MSB >> 5 | MSB >> 11 | MSB >> 24, // 1000
+                                     MSB | MSB >> 2 | MSB >> 5 | MSB >> 11 | MSB >> 25, // 1001
+                                     MSB | MSB >> 2 | MSB >> 5 | MSB >> 12 | MSB >> 26, // 1010
+                                     MSB | MSB >> 2 | MSB >> 5 | MSB >> 12 | MSB >> 27, // 1011
+
+                                     MSB | MSB >> 2 | MSB >> 6 | MSB >> 13 | MSB >> 28, // 1100
+                                     MSB | MSB >> 2 | MSB >> 6 | MSB >> 13 | MSB >> 29, // 1101
+                                     MSB | MSB >> 2 | MSB >> 6 | MSB >> 14 | MSB >> 30, // 1110
+                                     MSB | MSB >> 2 | MSB >> 6 | MSB >> 14 | MSB >> 31  /* 1111 */];
+
+#[inline]
+pub fn gen_bitmap(prefix: u8, masklen: u32) -> u32 {
+    debug_assert!(prefix < 16); // only nibbles allowed
+    debug_assert!(masklen < 5);
+    let ret = INTERNAL_LOOKUP_TABLE[masklen as usize][prefix as usize];
+    debug_assert!(ret > 0);
+    ret
+}
+
+/// ```Node ``` encodes result and child node pointers in a bitmap.
+///
+/// A trie node can encode up to 31 results when acting as an "end node", or 16
+/// results and 16 children/subtrees.
+///
+/// Each bit in the bitmap has the following meanings:
+///
+/// | bit   | 0 |  1 |  2 |  3  |   4 |   5 |   6 |    7 |
+/// |-------|---|----|----|-----|-----|-----|-----|------|
+/// | match | * | 0* | 1* | 00* | 01* | 10* | 11* | 000* |
+///
+/// | bit   |    8 |    9 |   10 |   11 |   12 |   13 |   14 |          15 |
+/// |-------|------|------|------|------|------|------|------|-------------|
+/// | match | 001* | 010* | 011* | 100* | 101* | 110* | 111* | endnode-bit |
+/// If the end node bit is set, the last bits are also used to match internal
+/// nodes:
+///
+/// | bit   |    16 |    17 |    18 |    19 |    20 |    21 |    22 |    23 |
+/// |-------|-------|-------|-------|-------|-------|-------|-------|-------|
+/// | match | 0000* | 0001* | 0010* | 0011* | 0100* | 0101* | 0110* | 0111* |
+///
+/// | bit   |    24 |    25 |    26 |    27 |    28 |    29 |    30 |    31 |
+/// |-------|-------|-------|-------|-------|-------|-------|-------|-------|
+/// | match | 1000* | 1001* | 1010* | 1011* | 1100* | 1101* | 1110* | 1111* |
+///
+/// The location of the result value is computed with the ```result_ptr``` base
+/// pointer and the number of bits set left of the matching bit.
+///
+/// If the endnode bit is not set, the last 16 bits encodes pointers to child
+/// nodes.
+/// If bit N is set it means that a child node with segment value N is present.
+/// The pointer to the child node is then computed with the ```child_ptr``` base
+/// pointer and the number of bits set left of N.
+#[derive(Clone, Copy)]
+pub struct Node {
+    /// child/result bitmap
+    bitmap: u32, // first 16 bits: internal, last 16 bits: child bitmap
+    /// child base pointer
+    pub child_ptr: u32,
+    /// results base pointer
+    pub result_ptr: u32,
+}
+
+pub const BIT_MATCH: [u32; 32] = [
+    0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 0, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+];
+
+#[rustfmt::skip]
+const BIT_MEANING: &[&str] = &[
+    "*",
+    "0*", "1*",
+    "00*", "01*", "10*", "11*",
+    "000*", "001*", "010*", "011*", "100*", "101*", "110*", "111*",
+    "END",
+    "0000*", "0001*", "0010*", "0011*", "0100*", "0101*", "0110*", "0111*",
+    "1000*", "1001*", "1010*", "1011*", "1100*", "1101*", "1110*", "1111*",
+];
+
+impl fmt::Debug for Node {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut int_nodes: Vec<&str> = Vec::new();
+        let mut child_nodes: Vec<u32> = Vec::new();
+        let mut selector = 1 << 31;
+        for meaning in BIT_MEANING {
+            if self.internal() & selector > 0 {
+                int_nodes.push(meaning);
+            }
+            selector >>= 1;
+        }
+
+        selector = 1 << 15;
+        for i in 0..16 {
+            if self.external() & selector > 0 {
+                child_nodes.push(i);
+            }
+            selector >>= 1;
+        }
+
+        let bitmap_string = format!("{:016b} {:016b}", self.bitmap >> 16, self.bitmap & EXT_MASK);
+
+        if self.is_endnode() {
+            return f
+                .debug_struct("EndNode")
+                .field("bitmap", &bitmap_string)
+                .field("internal", &int_nodes)
+                .field("result_ptr", &self.result_ptr)
+                .finish();
+        }
+        if self.is_blank() {
+            return f.debug_struct("BlankNode").finish();
+        }
+        f.debug_struct("InternalNode")
+            .field("bitmap", &bitmap_string)
+            .field("internal", &int_nodes)
+            .field("children", &child_nodes)
+            .field("child_ptr", &self.child_ptr)
+            .field("result_ptr", &self.result_ptr)
+            .finish()
+    }
+}
+
+impl Node {
+    /// Get a fresh, blank node.
+    pub fn new() -> Self {
+        Node {
+            bitmap: 0,
+            child_ptr: 0,
+            result_ptr: 0,
+        }
+    }
+
+    /// Is node blank?
+    pub fn is_blank(&self) -> bool {
+        self.bitmap == 0 && self.child_ptr == 0 && self.result_ptr == 0
+    }
+
+    /// Is node empty?
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.bitmap & END_BIT_MASK == 0
+    }
+
+    /// Is node an end node?
+    #[inline]
+    pub fn is_endnode(&self) -> bool {
+        self.bitmap & END_BIT > 0
+    }
+
+    /// Get internal bitmap (result entries). Any external bits are filtered.
+    #[inline]
+    pub fn internal(&self) -> u32 {
+        if self.is_endnode() {
+            self.bitmap & END_BIT_MASK // filter the end node bit
+        } else {
+            self.bitmap & INT_MASK
+        }
+    }
+
+    /// Get external bitmap (child entries). Any internal bits are filtered.
+    #[inline]
+    pub fn external(&self) -> u32 {
+        if self.is_endnode() {
+            0
+        } else {
+            self.bitmap & EXT_MASK
+        }
+    }
+
+    /// Set the endnode-bit.
+    /// # Panics
+    /// + if bit already set.
+    /// + if there are any external node pointers.
+    #[inline]
+    pub fn make_endnode(&mut self) {
+        debug_assert!(!self.is_endnode(), "make_endnode: already an endnode.");
+        debug_assert!(
+            self.external() == 0,
+            "cannot make into endnode when there are children present"
+        );
+        self.bitmap |= END_BIT
+    }
+
+    /// Unset the endnode-bit.
+    /// # Panics
+    /// + if not already an endnode.
+    #[inline]
+    pub fn make_normalnode(&mut self) {
+        debug_assert!(self.is_endnode(), "make_endnode: already a normalnode.");
+        self.bitmap &= END_BIT_MASK
+    }
+
+    /// Get number of child pointers.
+    #[inline]
+    pub fn child_count(&self) -> u32 {
+        self.external().count_ones()
+    }
+
+    /// Get number of result pointers.
+    #[inline]
+    pub fn result_count(&self) -> u32 {
+        self.internal().count_ones()
+    }
+
+    /// Get handle to the results.
+    #[inline]
+    pub fn result_handle(&self) -> AllocatorHandle {
+        AllocatorHandle::generate(self.result_count(), self.result_ptr)
+    }
+
+    /// Get handle to child nodes.
+    #[inline]
+    pub fn child_handle(&self) -> AllocatorHandle {
+        AllocatorHandle::generate(self.child_count(), self.child_ptr)
+    }
+
+    /// Set an internal bit.
+    #[inline]
+    pub fn set_internal(&mut self, bitmap: u32) {
+        debug_assert!(
+            bitmap.count_ones() == 1,
+            "set_internal: bitmap must contain exactly one bit"
+        );
+        debug_assert!(
+            bitmap & END_BIT == 0,
+            "set_internal: not permitted to set the endnode bit"
+        );
+        debug_assert!(self.bitmap & bitmap == 0, "set_internal: bit already set");
+        if !self.is_endnode() {
+            debug_assert!(
+                bitmap & EXT_MASK == 0,
+                "set_internal: attempted to set external bit"
+            );
+        }
+        self.bitmap |= bitmap
+    }
+
+    /// Unset an internal bit.
+    #[inline]
+    pub fn unset_internal(&mut self, bitmap: u32) {
+        debug_assert!(
+            bitmap.count_ones() == 1,
+            "unset_internal: bitmap must contain exactly one bit"
+        );
+        debug_assert!(
+            bitmap & END_BIT == 0,
+            "unset_internal: not permitted to set the endnode bit"
+        );
+        debug_assert!(
+            self.bitmap & bitmap == bitmap,
+            "unset_internal: bit already unset"
+        );
+        if !self.is_endnode() {
+            debug_assert!(
+                bitmap & EXT_MASK == 0,
+                "unset_internal: attempted to set external bit"
+            );
+        }
+        self.bitmap ^= bitmap
+    }
+
+    /// Set an external bit.
+    #[inline]
+    pub fn set_external(&mut self, bitmap: u32) {
+        debug_assert!(
+            !self.is_endnode(),
+            "set_external: endnodes don't have external bits"
+        );
+        debug_assert!(
+            bitmap & END_BIT == 0,
+            "set_external: not permitted to set the endnode bit"
+        );
+        debug_assert!(
+            self.bitmap & bitmap == 0,
+            "set_external: not permitted to set an already set bit"
+        );
+        debug_assert!(
+            bitmap & INT_MASK == 0,
+            "set_external: not permitted to set an internal bit"
+        );
+        self.bitmap |= bitmap
+    }
+
+    pub fn unset_external(&mut self, bitmap: u32) {
+        debug_assert!(
+            !self.is_endnode(),
+            "unset_external: endnodes don't have external bits"
+        );
+        debug_assert!(
+            bitmap & END_BIT == 0,
+            "unset_external: not permitted to set the endnode bit"
+        );
+        debug_assert!(
+            self.bitmap & bitmap == bitmap,
+            "unset_external: not permitted to unset an already unset bit"
+        );
+        debug_assert!(
+            bitmap & INT_MASK == 0,
+            "unset_external: not permitted to set an internal bit"
+        );
+        self.bitmap ^= bitmap
+    }
+
+    /// Perform a match on segment/masklen.
+    #[inline]
+    pub fn match_segment(&self, segment: u8) -> MatchResult {
+        let match_mask = MATCH_MASKS[segment as usize];
+        match self.match_external(match_mask) {
+            MatchResult::None => self.match_internal(match_mask),
+            x => x,
+        }
+    }
+
+    #[inline]
+    pub fn match_internal(&self, match_mask: u32) -> MatchResult {
+        let result_match = self.internal() & match_mask;
+        if result_match > 0 {
+            let result_hdl = self.result_handle();
+            let best_match_bit_index = 31 - result_match.trailing_zeros();
+            let best_match_result_index = match best_match_bit_index {
+                0 => 0,
+                _ => (self.internal() >> (32 - best_match_bit_index)).count_ones(),
+            };
+            return MatchResult::Match(result_hdl, best_match_result_index, best_match_bit_index);
+        }
+        MatchResult::None
+    }
+
+    #[inline]
+    pub fn match_external(&self, match_mask: u32) -> MatchResult {
+        let child_match = self.external() & match_mask;
+        if child_match > 0 {
+            let child_hdl = self.child_handle();
+            let best_match_bit_index = 31 - child_match.trailing_zeros();
+            let best_match_child_index = match best_match_bit_index {
+                0 => 0,
+                _ => (self.external() >> (32 - best_match_bit_index)).count_ones(),
+            };
+            return MatchResult::Chase(child_hdl, best_match_child_index);
+        }
+        MatchResult::None
+    }
+}
+
+#[derive(Debug)]
+pub enum MatchResult {
+    Match(AllocatorHandle, u32, u32), // result_handle, offset, matching bits
+    Chase(AllocatorHandle, u32),      // child_handle, offset
+    None,                             // Node does not match
+}


### PR DESCRIPTION
## Before

```
=== BENCHMARK RESULTS ===
Networks: 100000 (50000 IPv4, 50000 IPv6)
Lookups: 10000

RadixTarget:
  Insert time: 2393.22ms
  Lookup time: 107.66ms
  Operations/sec: 92883
  Hit rate: 100.0%

ip_network_table:
  Insert time: 430.34ms
  Lookup time: 7.49ms
  Operations/sec: 1334260
  Hit rate: 100.0%

Performance comparison (RadixTarget vs ip_network_table):
  Insert: ip_network_table is 5.56x faster
  Lookup: ip_network_table is 14.36x faster
```

## After
```
=== BENCHMARK RESULTS ===
Networks: 100000 (50000 IPv4, 50000 IPv6)
Lookups: 10000

RadixTarget:
  Insert time: 528.80ms
  Lookup time: 39.90ms
  Operations/sec: 250620
  Hit rate: 100.0%

ip_network_table:
  Insert time: 281.00ms
  Lookup time: 7.77ms
  Operations/sec: 1287706
  Hit rate: 100.0%

Performance comparison (RadixTarget vs ip_network_table):
  Insert: ip_network_table is 1.88x faster
  Lookup: ip_network_table is 5.14x faster
```